### PR TITLE
Upgrade Tenjin messaging Nuget package and renamed PubSub component n…

### DIFF
--- a/src/.net/Tenjin.Autofac.Tests/ExtensionsTests/AutofacContainerPublisherExtensionsTests.cs
+++ b/src/.net/Tenjin.Autofac.Tests/ExtensionsTests/AutofacContainerPublisherExtensionsTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using Tenjin.Autofac.Extensions;
 using Tenjin.Autofac.Tests.Constants;
 using Tenjin.Autofac.Tests.Utilities;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
 namespace Tenjin.Autofac.Tests.ExtensionsTests
 {

--- a/src/.net/Tenjin.Autofac.Tests/Implementations/Messaging/EnumPublishers.cs
+++ b/src/.net/Tenjin.Autofac.Tests/Implementations/Messaging/EnumPublishers.cs
@@ -1,6 +1,6 @@
 ﻿using Tenjin.Autofac.Tests.Enums;
-using Tenjin.Implementations.Messaging;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Implementations.Messaging.PublisherSubscriber;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
 namespace Tenjin.Autofac.Tests.Implementations.Messaging
 {

--- a/src/.net/Tenjin.Autofac.Tests/Implementations/Messaging/Int32Publishers.cs
+++ b/src/.net/Tenjin.Autofac.Tests/Implementations/Messaging/Int32Publishers.cs
@@ -1,6 +1,6 @@
 ﻿using Tenjin.Autofac.Tests.Constants;
-using Tenjin.Implementations.Messaging;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Implementations.Messaging.PublisherSubscriber;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
 namespace Tenjin.Autofac.Tests.Implementations.Messaging
 {

--- a/src/.net/Tenjin.Autofac.Tests/Implementations/Messaging/StringPublishers.cs
+++ b/src/.net/Tenjin.Autofac.Tests/Implementations/Messaging/StringPublishers.cs
@@ -1,6 +1,6 @@
 ﻿using Tenjin.Autofac.Tests.Constants;
-using Tenjin.Implementations.Messaging;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Implementations.Messaging.PublisherSubscriber;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
 namespace Tenjin.Autofac.Tests.Implementations.Messaging
 {

--- a/src/.net/Tenjin.Autofac.Tests/ImplementationsTests/MessagingTests/PublisherSubscriberTests/AutofacPublisherRegistryTests.cs
+++ b/src/.net/Tenjin.Autofac.Tests/ImplementationsTests/MessagingTests/PublisherSubscriberTests/AutofacPublisherRegistryTests.cs
@@ -5,9 +5,9 @@ using Tenjin.Autofac.Tests.Constants;
 using Tenjin.Autofac.Tests.Enums;
 using Tenjin.Autofac.Tests.Models.Messaging;
 using Tenjin.Autofac.Tests.Utilities;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
-namespace Tenjin.Autofac.Tests.ImplementationsTests.MessagingTests
+namespace Tenjin.Autofac.Tests.ImplementationsTests.MessagingTests.PublisherSubscriberTests
 {
     [TestFixture]
     public class AutofacPublisherRegistryTests

--- a/src/.net/Tenjin.Autofac.Tests/Utilities/PublishRegistryContainerUtilities.cs
+++ b/src/.net/Tenjin.Autofac.Tests/Utilities/PublishRegistryContainerUtilities.cs
@@ -2,7 +2,7 @@
 using Tenjin.Autofac.Extensions;
 using Tenjin.Autofac.Tests.Enums;
 using Tenjin.Autofac.Tests.Implementations.Messaging;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
 namespace Tenjin.Autofac.Tests.Utilities
 {

--- a/src/.net/Tenjin.Autofac/Extensions/AutofacContainerPublisherExtensions.cs
+++ b/src/.net/Tenjin.Autofac/Extensions/AutofacContainerPublisherExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Autofac;
-using Tenjin.Autofac.Implementations.Messaging;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Autofac.Implementations.Messaging.PublisherSubscriber;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
 namespace Tenjin.Autofac.Extensions
 {

--- a/src/.net/Tenjin.Autofac/Implementations/Messaging/PublisherSubscriber/AutofacPublisherRegistry.cs
+++ b/src/.net/Tenjin.Autofac/Implementations/Messaging/PublisherSubscriber/AutofacPublisherRegistry.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
-using Tenjin.Implementations.Messaging;
-using Tenjin.Interfaces.Messaging;
+using Tenjin.Implementations.Messaging.PublisherSubscriber;
+using Tenjin.Interfaces.Messaging.PublishSubscriber;
 
-namespace Tenjin.Autofac.Implementations.Messaging
+namespace Tenjin.Autofac.Implementations.Messaging.PublisherSubscriber
 {
     public class AutofacPublisherRegistry<TKey, TData> : PublisherRegistry<TKey, TData> where TKey : notnull
     {

--- a/src/.net/Tenjin.Autofac/Tenjin.Autofac.csproj
+++ b/src/.net/Tenjin.Autofac/Tenjin.Autofac.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="Tenjin" Version="1.5.0.59" />
+    <PackageReference Include="Tenjin" Version="1.6.0.62" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/azure-pipelines.yml
+++ b/src/azure-pipelines.yml
@@ -25,7 +25,7 @@ variables:
   coreVersion: "6.x"
   major: 1
   minor: 2
-  revision: 0
+  revision: 1
   buildNumber: $[counter(variables['major'], 0)]
   ${{ if or(contains(variables['Build.SourceBranch'], 'feature/'), contains(variables['Build.SourceBranch'], 'bug-fix/'))  }}:
     releaseType: '-alpha'


### PR DESCRIPTION
20220510 - Updated the Tenjin nuget package.
20220510 - Renamed the PubSub namespaces to match the Tenjin nuget package namespaces.